### PR TITLE
fix in-project use case

### DIFF
--- a/git_dummy/__main__.py
+++ b/git_dummy/__main__.py
@@ -16,7 +16,7 @@ def main(
         settings.name,
         help="Name of the dummy repo",
     ),
-    git_dir: str = typer.Option(
+    git_dir: Path = typer.Option(
         settings.git_dir,
         help="The path in which to create the dummy Git repo",
     ),
@@ -53,13 +53,12 @@ def main(
     settings.no_subdir = no_subdir
     settings.constant_sha = constant_sha
 
-    orig_git_dir = Path('.').resolve() if not git_dir else Path(git_dir).resolve()
-    print(f'Staring with git dir: {orig_git_dir}')
+    orig_git_dir = Path('.').resolve() if not git_dir else git_dir.resolve()
+    print(f"Starting with git dir: {orig_git_dir}")
     settings.git_dir = orig_git_dir / settings.name
     if settings.no_subdir:
         settings.git_dir = Path().cwd()
 
-    # this is really our error condition if it finds an existing git repository
     try:
         git.Repo(settings.git_dir, search_parent_directories=True)
         print(
@@ -67,7 +66,6 @@ def main(
         )
         sys.exit(1)
     except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
-        # this is our success condition since it means we can create a repository
         print(
             f"git-dummy: Generating dummy Git repo at {settings.git_dir} with {settings.branches} branch(es) and {settings.commits} commit(s)."
         )


### PR DESCRIPTION
As mentioned in issue #3 it was failing to create a dummy repository in a subdir of my project checkout and this fixes it for me (and still fails with the right conditions). First, it uses a single try/except block, and sets the target path before entering that block.  We also let the input path be a str and then make the actual settings attribute a proper Path and value before trying to use it.

And now it works nicely inside a pytest fixture to create test repos  :rocket: 